### PR TITLE
chore(deps)!: semantic-release@19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [16.x]
 
     steps:
       - name: Checkout
@@ -46,11 +46,11 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - run: npm i
 
       - name: Publish
-        run: npm run release -- --dry-run --no-ci --branches=${{github.head_ref}} --branches=${{github.ref}}
+        run: npm run release -- --dry-run --no-ci --branches=${{github.head_ref}}
         env:
           GITHUB_EVENT_NAME: 'dummy'
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - run: npm i
       - name: Publish
         run: npm run release

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "debug": "^4.3.1",
     "eslint": "^7.16.0",
     "execa": "^5.0.0",
-    "multi-semantic-release": "^2.8.0",
+    "multi-semantic-release": "^2.11.1",
     "nopt": "^5.0.0",
     "semantic-release": "^19.0.2",
     "tap": "^14.11.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
-    "@semantic-release/git": "^9.0.0",
+    "@semantic-release/git": "^10.0.1",
     "eslint-config-codedependant": "^2.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/esatterwhite/multi-release#readme",
   "tap": {
     "100": true,
-    "esm": false,
     "ts": false,
     "jsx": false,
     "timeout": 240,
@@ -67,7 +66,9 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "eslint-config-codedependant": "^2.0.0"
+    "eslint-config-codedependant": "^2.0.0",
+    "eslint-plugin-node": "^11.1.0",
+    "tap": "^16.0.0"
   },
   "dependencies": {
     "debug": "^4.3.1",
@@ -75,7 +76,6 @@
     "execa": "^5.0.0",
     "multi-semantic-release": "^2.11.1",
     "nopt": "^5.0.0",
-    "semantic-release": "^19.0.2",
-    "tap": "^14.11.0"
+    "semantic-release": "^19.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "execa": "^5.0.0",
     "multi-semantic-release": "^2.8.0",
     "nopt": "^5.0.0",
-    "semantic-release": "^17.4.2",
+    "semantic-release": "^19.0.2",
     "tap": "^14.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     }
   },
   "devDependencies": {
-    "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^9.0.0",
     "eslint-config-codedependant": "^2.0.0"
   },


### PR DESCRIPTION
update requirement of semantic release 19

BREAKING CHANGE: minimum node version is 16